### PR TITLE
Update install.md to forward users directly to download section

### DIFF
--- a/install.md
+++ b/install.md
@@ -16,7 +16,7 @@ Anaconda is an easy way to install *Jupyter Notebooks*, which is an even easier 
 
 # Download and install Anaconda 
 
-1. Go to the [Anaconda Website](https://www.anaconda.com/download) and choose a Python 3.x graphical installer.
+1. Go to the [Anaconda Website](https://www.anaconda.com/download/success) and choose a Python 3.x graphical installer.
 2. Locate your download and double click it.
 3. Pay attention to Anaconda's installation instructions.
     - the installation path must not contain spaces. 


### PR DESCRIPTION
Anaconda requires new visitors of their website to fill in their email address and confirm before they can access the download section.

This additional step creates friction and requires the user to sign up with a personal email before the user is forwarded to the download section. 

Instead, send the user to the forwarded link directly: https://www.anaconda.com/download/success

Instead, I suggest to use